### PR TITLE
:bug: use named tuple instead of return order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV PATH="/usr/src/app/venv/bin:$PATH"
 
 COPY requirements.txt .
 
+RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev
 RUN pip3 install --requirement requirements.txt
 
 FROM alpine:3.15
@@ -21,6 +22,8 @@ WORKDIR /usr/src/app
 RUN apk add --update --no-cache python3 gcc g++
 
 RUN apk add --update --no-cache git make libcap-dev asciidoc
+
+RUN apk --no-cache add libpq   
 
 RUN git clone https://github.com/ioi/isolate.git
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 tabulate==0.8.7
 mysql-connector-python==8.0.23
-psycopg-binary==3.0.7
-psycopg==3.0.7
+psycopg2==2.9.6
 pyyaml==6.0
 requests==2.27.1

--- a/src/mainPostgresql.py
+++ b/src/mainPostgresql.py
@@ -21,16 +21,16 @@ def main():
             time.sleep(1)
             continue
         subDTO = SubmissionDTO(
-            id=queue[0],
-            userId=queue[1],
-            problemId=queue[2],
-            contestId=queue[8],
-            sourceCode=queue[9],
-            language=queue[10],
-            maxScore=queue[16],
-            timeLimit=queue[17],
-            memoryLimit=queue[18],
-            testcase=queue[21],
+            id=queue.id,
+            userId=queue.userId,
+            problemId=queue.problemId,
+            contestId=queue.contestId,
+            sourceCode=queue.sourceCode,
+            language=queue.language,
+            maxScore=queue.maxScore,
+            timeLimit=queue.timeLimit,
+            memoryLimit=queue.memoryLimit,
+            testcase=queue.case,
             mode="classic"
         )
         judge.startJudge(subDTO, updateResult, updateRunningInCase)

--- a/src/mainPostgresqlModBalance.py
+++ b/src/mainPostgresqlModBalance.py
@@ -19,22 +19,22 @@ def main():
         nGrader, thisGrader = int(osEnv.LOAD_BALANCE_N_GRADER), int(
             osEnv.LOAD_BALANCE_THIS_GRADER)
         queue = getQueueModBalace(nGrader, thisGrader)
-        getQueue()
+        getQueue() # why do we need another getQueue btw
         if not queue:
             DBDisconnect()
             time.sleep(1)
             continue
         subDTO = SubmissionDTO(
-            id=queue[0],
-            userId=queue[1],
-            problemId=queue[2],
-            contestId=queue[8],
-            sourceCode=queue[9],
-            language=queue[10],
-            maxScore=queue[16],
-            timeLimit=queue[17],
-            memoryLimit=queue[18],
-            testcase=queue[21],
+            id=queue.id,
+            userId=queue.userId,
+            problemId=queue.problemId,
+            contestId=queue.contestId,
+            sourceCode=queue.sourceCode,
+            language=queue.language,
+            maxScore=queue.maxScore,
+            timeLimit=queue.timeLimit,
+            memoryLimit=queue.memoryLimit,
+            testcase=queue.case,
             mode="classic"
         )
         judge.startJudge(subDTO, updateResult, updateRunningInCase)

--- a/src/postgresql/dbInit.py
+++ b/src/postgresql/dbInit.py
@@ -1,12 +1,13 @@
 import traceback
-import psycopg
+import psycopg2
+import psycopg2.extras
 
 from constants.colors import colors
 from .dbConfig import dbConfig
 
 
 def init():
-    return psycopg.connect(**dbConfig)
+    return psycopg2.connect(**dbConfig)
 
 
 class DB:
@@ -24,7 +25,7 @@ class DB:
 
     def query(self, sql, value=()):
         try:
-            cursor = self.conn.cursor()
+            cursor = self.conn.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
             cursor.execute(sql, value)
             return cursor
         except Exception:

--- a/src/postgresql/dbQuery.py
+++ b/src/postgresql/dbQuery.py
@@ -48,7 +48,7 @@ def getQueueModBalace(nGrader:int, thisGrader:int):
     #thisGrader will count from 1 to nGrader
     db.update()
     cur = db.query(
-        f"""SELECT * FROM submission as S
+        f"""SELECT S.*, B."timeLimit", B."memoryLimit", B."case", B."score" as "maxScore" FROM submission as S
             LEFT JOIN problem as B ON S."problemId" = B."id"
             WHERE status = 'waiting' AND mod(S.id,{nGrader}) = {thisGrader - 1} ORDER BY S."creationDate" """
     )
@@ -59,7 +59,7 @@ def getQueueModBalace(nGrader:int, thisGrader:int):
 def getQueue():
     db.update()
     cur = db.query(
-        f"""SELECT * FROM submission as S
+        f"""SELECT S.*, B."timeLimit", B."memoryLimit", B."case", B."score" as "maxScore" FROM submission as S
             LEFT JOIN problem as B ON S."problemId" = B."id"
             WHERE status = 'waiting' ORDER BY S."creationDate" """
     )


### PR DESCRIPTION
There is a problem in the code below that it doesn't always return a row in the same order

<img width="256" alt="Screenshot 2566-05-24 at 03 06 22" src="https://github.com/phakphum-dev/otog-grader/assets/51981658/9ffce267-c833-496b-bb87-db3890c0a559">

For example, `queue[21]` can be a `testcase` in a system but a `timestamp` in another system

What I found is that we can use named dict/tuple from db query

https://stackoverflow.com/a/21158159

but i needed to upgrade to `psycopg2` and did some weird installation to make it work with alpine

Ref: https://github.com/psycopg/psycopg2/issues/684

Please review!
